### PR TITLE
Configurable Bodymovin & Bodymovin_light support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,20 @@ export default App
 
 ## File size
 
-Bodymovin is pretty huge, sadly, so you may want to load this dependency optionally somehow if you don't need it on every page. I depend on the "light" version which only supports SVG to make it a little smaller.
+Bodymovin is pretty huge, sadly, so you may want to load this dependency optionally somehow if you don't need it on every page. By default this will use the minified "light" version which only supports SVG to make it a little smaller.
+
+If you need the full Bodymovin library with expression support, this is possible by adding a line in your `webpack.DefinePlugin` configuration as shown below:
+
+```js
+plugins: ([
+	new webpack.DefinePlugin({
+    //Set true for the full bodymovin.min and false for bodymovin_light.min
+		BODYMOVIN_EXPRESSION_SUPPORT: true
+	})
+])
+```
+
+Simply set to true for the full `bodymovin.min.js` with expression support, and set to false for `bodymovin_light.min.js` which doesn't support expressions, but is smaller, as shown below:
 
 | Bodymovin file sizes | Normal | Light |
 |----------------------|--------|-------|

--- a/src/ReactBodymovin.js
+++ b/src/ReactBodymovin.js
@@ -1,5 +1,5 @@
 const React = require('react')
-const bodymovin = require('bodymovin/build/player/bodymovin_light')
+const bodymovin = BODYMOVIN_EXPRESSION_SUPPORT ? require('bodymovin/build/player/bodymovin.min') : require('bodymovin/build/player/bodymovin_light.min') 
 
 class ReactBodymovin extends React.Component {
   componentDidMount () {


### PR DESCRIPTION
This is just a pretty simple change that allows you to configure which
bodymovin library you want to use in your `webpack.config.js`. I needed
to use expressions (and thus the full bodymovin.js), and I figured
others might appreciate the option as well.

By default it will still use bodymovin_light, and doesn’t require
configuration in the webpack config, so it should be backwards
compatible, and anyone that doesn’t need / want to configure the
library don’t have to.