### PR TITLE
Extend returned div to wrap this.props.children

### DIFF
--- a/src/ReactBodymovin.js
+++ b/src/ReactBodymovin.js
@@ -25,11 +25,16 @@ class ReactBodymovin extends React.Component {
   }
 
   render () {
+
     const storeWrapper = (el) => {
       this.wrapper = el
     }
 
-    return <div className='react-bodymovin-container' ref={storeWrapper} />
+    return (
+      <div className='react-bodymovin-container' ref={storeWrapper}>
+        { this.props.children }
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
Simple change to allow you to use `ReactBodymovin` with content. An example use-case would be absolutely positioning some content, like a title, over the animation.

![screen shot 2017-09-29 at 15 44 06](https://user-images.githubusercontent.com/1838917/31021215-16b1087e-a52d-11e7-99ad-f074bc0243f9.png)

```
<ReactBodymovin>
  <h1 style={{ position: 'absolute' }}>You're covered</h1>
</ReactBodymovin>
```